### PR TITLE
Fix TabNavigation when cycling ItemsRepeater elements

### DIFF
--- a/SimpleTwitchEmoteSounds/Views/DashboardView.axaml
+++ b/SimpleTwitchEmoteSounds/Views/DashboardView.axaml
@@ -70,6 +70,7 @@
             <StackPanel HorizontalAlignment="Center">
                 <ItemsRepeater HorizontalAlignment="Center"
                                ItemsSource="{Binding FilteredSoundCommands}"
+                               KeyboardNavigation.TabNavigation="Continue"
                                Margin="15">
                     <ItemsRepeater.Layout>
                         <WrapLayout Orientation="Horizontal" />


### PR DESCRIPTION
I found the weird bug that when using `TAB` to cycle clickable elements it worked until I reached the elements generated by the `ItemsRepeater` in `Views/DashboardView.axaml` where only the first button of the first element is selected and then it cycles back to the top.
After a quick search ([seems to be a known issue](https://github.com/AvaloniaUI/Avalonia.Controls.ItemsRepeater/issues/23#issuecomment-2225100710)) I found that simply adding the property `KeyboardNavigation.TabNavigation="Continue"` fixes the issue and cycles properly through all generated elements and their buttons.